### PR TITLE
ft/reset-pagination-search

### DIFF
--- a/cmr_etl_lib/audit_logger/service/audit_service.py
+++ b/cmr_etl_lib/audit_logger/service/audit_service.py
@@ -17,13 +17,14 @@ def get_audit_logs_paginated(args, data):
     collection = AuditTrail().db()
     skip = max((page - 1) * per_page, 0)
     
-    if query: 
-        skip = 0
-        per_page = 10
     
     if "action" not in query:
         query["action"] = {"$ne": "RETRIEVE"}
     
+    total = AuditTrail.count(query)
+    if skip >= total:
+        skip = max(total - per_page, 0)
+            
     total_items = collection.aggregate(
         [
             {"$match": query},
@@ -34,6 +35,5 @@ def get_audit_logs_paginated(args, data):
     )
 
     data = [AuditTrail(**entity) for entity in total_items]
-    total = collection.find(query, {"_id": 1}).count()
 
     return Paginator(data, page, per_page, total)

--- a/cmr_etl_lib/audit_logger/service/audit_service.py
+++ b/cmr_etl_lib/audit_logger/service/audit_service.py
@@ -8,8 +8,6 @@ from cmr_etl_lib.filters import build_filters
 def get_audit_logs_paginated(args, data):
     query = build_filters(data.get("filters", []))
 
-    if "action" not in query:
-        query["action"] = {"$ne": "RETRIEVE"}
 
     page = args.get("page")
     per_page = args.get("size")
@@ -18,6 +16,14 @@ def get_audit_logs_paginated(args, data):
 
     collection = AuditTrail().db()
     skip = max((page - 1) * per_page, 0)
+    
+    if query: 
+        skip = 0
+        per_page = 10
+    
+    if "action" not in query:
+        query["action"] = {"$ne": "RETRIEVE"}
+    
     total_items = collection.aggregate(
         [
             {"$match": query},

--- a/cmr_etl_lib/document.py
+++ b/cmr_etl_lib/document.py
@@ -85,3 +85,14 @@ class Document:
         # for k, v in data.items():
         #     self.__setattr__(k, v)
         # return self
+        
+    @classmethod
+    def count(cls, query=None):
+        """
+        Count documents matching the query.
+        
+        :param query: dict, The filter query (default: {}).
+        :return: int, Number of matching documents.
+        """
+        query = query or {}
+        return cls().db().count_documents(query)


### PR DESCRIPTION
Refactor pagination logic in get_audit_logs_paginated to reset skip and per_page based on query search